### PR TITLE
Feature/res net

### DIFF
--- a/models/ResNet.py
+++ b/models/ResNet.py
@@ -1,0 +1,85 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torchvision import models
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+# ResNet-18 모델 정의
+class MNISTResNet(nn.Module):
+    def __init__(self, num_classes=10):
+        super(MNISTResNet, self).__init__()
+        self.model = models.resnet18(pretrained=True)
+        self.model.conv1 = nn.Conv2d(1, 64, kernel_size=3, stride=1, padding=1, bias=False)  # 흑백 이미지 지원
+        self.model.fc = nn.Linear(self.model.fc.in_features, num_classes)  # MNIST는 10개 클래스
+    
+    def forward(self, x):
+        return self.model(x)
+
+# 학습 함수
+def train(model, criterion, optimizer, train_loader, val_loader, epochs=10):
+    best_acc = 0.0
+    for epoch in range(epochs):
+        model.train()
+        running_loss = 0.0
+        correct = 0
+        total = 0
+        
+        for images, labels in train_loader:
+            images, labels = images.to(device), labels.to(device)
+            optimizer.zero_grad()
+            outputs = model(images)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+            
+            running_loss += loss.item()
+            _, predicted = outputs.max(1)
+            total += labels.size(0)
+            correct += predicted.eq(labels).sum().item()
+        
+        train_acc = correct / total
+        val_acc = evaluate(model, val_loader)
+        print(f"Epoch [{epoch+1}/{epochs}], Loss: {running_loss/len(train_loader):.4f}, Train Acc: {train_acc:.4f}, Val Acc: {val_acc:.4f}")
+        
+        if val_acc > best_acc:
+            best_acc = val_acc
+            torch.save(model.state_dict(), "ResNet_models/best_ResNet_model.pth")
+            print("Best model saved!")
+
+# 검증 함수
+def evaluate(model, loader):
+    model.eval()
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for images, labels in loader:
+            images, labels = images.to(device), labels.to(device)
+            outputs = model(images)
+            _, predicted = outputs.max(1)
+            total += labels.size(0)
+            correct += predicted.eq(labels).sum().item()
+    return correct / total
+
+# 테스트 함수
+def test_ResNet(model, test_loader):
+    model.load_state_dict(torch.load("ResNet_models/best_ResNet_model.pth"))
+    test_acc = evaluate(model, test_loader)
+    print(f"Test Accuracy: {test_acc:.4f}")
+    return test_acc
+
+# 학습 실행 함수
+def run_learning_ResNet(train_loader, val_loader, test_loader, lr=0.001, only_test=False):
+    # 모델 초기화
+    model = MNISTResNet().to(device)
+
+    # 손실 함수 및 옵티마이저 정의
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.Adam(model.parameters(), lr=lr)
+    
+    if only_test:
+        test_acc = test_ResNet(model, test_loader)
+        return test_acc
+    
+    train(model, criterion, optimizer, train_loader, val_loader)
+    test_ResNet(model, test_loader)

--- a/models/ResNet.py
+++ b/models/ResNet.py
@@ -1,3 +1,4 @@
+import os
 import torch
 import torch.nn as nn
 import torch.optim as optim
@@ -21,6 +22,8 @@ class MNISTResNet(nn.Module):
 # 학습 함수
 def train(model, criterion, optimizer, train_loader, val_loader, epochs=10):
     best_acc = 0.0
+    os.makedirs("ResNet_models", exist_ok=True)  # 폴더가 없으면 생성
+    
     for epoch in range(epochs):
         model.train()
         running_loss = 0.0

--- a/models/ResNet.py
+++ b/models/ResNet.py
@@ -19,6 +19,13 @@ class MNISTResNet(nn.Module):
     def forward(self, x):
         return self.model(x)
 
+# 모델 함수
+def load_ResNet_model(best=False):
+    model = MNISTResNet().to(device)
+    if best:
+        model.load_state_dict(torch.load("ResNet_models/best_ResNet_model.pth"))
+    return model
+
 # 학습 함수
 def train(model, criterion, optimizer, train_loader, val_loader, epochs=10):
     best_acc = 0.0
@@ -67,8 +74,8 @@ def evaluate(model, loader):
     return correct / total
 
 # 테스트 함수
-def test_ResNet(model, test_loader):
-    model.load_state_dict(torch.load("ResNet_models/best_ResNet_model.pth"))
+def test_ResNet(test_loader):
+    model = load_ResNet_model(best=True)
     test_acc = evaluate(model, test_loader)
     print(f"Test Accuracy: {test_acc:.4f}")
     return test_acc
@@ -76,7 +83,7 @@ def test_ResNet(model, test_loader):
 # 학습 실행 함수
 def run_ResNet(train_loader, val_loader, test_loader, lr=0.001, only_test=False):
     # 모델 초기화
-    model = MNISTResNet().to(device)
+    model = load_ResNet_model()
     
     # 손실 함수 및 옵티마이저 정의
     criterion = nn.CrossEntropyLoss()
@@ -90,7 +97,9 @@ def run_ResNet(train_loader, val_loader, test_loader, lr=0.001, only_test=False)
     test_ResNet(model, test_loader)
 
 # 랜덤 샘플 시각화 함수
-def visualize_predictions(model, data_loader, num_samples=5):
+def ResNet_visualize_predictions(data_loader, num_samples=5):
+    model = load_ResNet_model(best=True)
+    
     model.eval()
     images, labels = next(iter(data_loader))
     indices = np.random.choice(len(images), num_samples, replace=False)

--- a/models/ResNet.py
+++ b/models/ResNet.py
@@ -1,6 +1,8 @@
 import torch
 import torch.nn as nn
 import torch.optim as optim
+import matplotlib.pyplot as plt
+import numpy as np
 from torchvision import models
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -69,7 +71,7 @@ def test_ResNet(model, test_loader):
     return test_acc
 
 # 학습 실행 함수
-def run_learning_ResNet(train_loader, val_loader, test_loader, lr=0.001, only_test=False):
+def run_ResNet(train_loader, val_loader, test_loader, lr=0.001, only_test=False):
     # 모델 초기화
     model = MNISTResNet().to(device)
 
@@ -83,3 +85,23 @@ def run_learning_ResNet(train_loader, val_loader, test_loader, lr=0.001, only_te
     
     train(model, criterion, optimizer, train_loader, val_loader)
     test_ResNet(model, test_loader)
+
+# 랜덤 샘플 시각화 함수
+def visualize_predictions(model, data_loader, num_samples=5):
+    model.eval()
+    images, labels = next(iter(data_loader))
+    indices = np.random.choice(len(images), num_samples, replace=False)
+    images, labels = images[indices], labels[indices]
+    
+    images = images.to(device)
+    with torch.no_grad():
+        outputs = model(images)
+        _, predictions = torch.max(outputs, 1)
+    
+    images = images.cpu().numpy()
+    fig, axes = plt.subplots(1, num_samples, figsize=(12, 3))
+    for i, ax in enumerate(axes):
+        ax.imshow(images[i][0], cmap='gray')
+        ax.set_title(f"Pred: {predictions[i].item()}\nLabel: {labels[i].item()}")
+        ax.axis("off")
+    plt.show()

--- a/models/ResNet.py
+++ b/models/ResNet.py
@@ -77,14 +77,14 @@ def evaluate(model, loader):
     return correct / total
 
 # 테스트 함수
-def test_ResNet(test_loader):
-    model = load_ResNet_model(best=True)
+def test_ResNet(test_loader, path='best_ResNet_model.pth'):
+    model = load_ResNet_model(best=True, path=path)
     test_acc = evaluate(model, test_loader)
     print(f"Test Accuracy: {test_acc:.4f}")
     return test_acc
 
 # 학습 실행 함수
-def run_ResNet(train_loader, val_loader, test_loader, lr=0.001, only_test=False):
+def run_ResNet(train_loader, val_loader, test_loader, lr=0.001, only_test=False, path='best_ResNet_model.pth'):
     # 모델 초기화
     model = load_ResNet_model()
     
@@ -97,11 +97,11 @@ def run_ResNet(train_loader, val_loader, test_loader, lr=0.001, only_test=False)
         return test_acc
     
     train(model, criterion, optimizer, train_loader, val_loader)
-    test_ResNet(test_loader)
+    test_ResNet(test_loader, path=path)
 
 # 랜덤 샘플 시각화 함수
-def ResNet_visualize_predictions(data_loader, num_samples=5):
-    model = load_ResNet_model(best=True)
+def ResNet_visualize_predictions(data_loader, num_samples=5, path='best_ResNet_model.pth'):
+    model = load_ResNet_model(best=True, path=path)
     
     model.eval()
     images, labels = next(iter(data_loader))

--- a/models/ResNet.py
+++ b/models/ResNet.py
@@ -7,6 +7,7 @@ import numpy as np
 from torchvision import models
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # ResNet-18 모델 정의
 class MNISTResNet(nn.Module):
@@ -20,16 +21,18 @@ class MNISTResNet(nn.Module):
         return self.model(x)
 
 # 모델 함수
-def load_ResNet_model(best=False):
+def load_ResNet_model(best=False, path='best_ResNet_model.pth'):
     model = MNISTResNet().to(device)
     if best:
-        model.load_state_dict(torch.load("ResNet_models/best_ResNet_model.pth"))
+        path = os.path.join(BASE_DIR, "models/ResNet_models", path)
+        model.load_state_dict(torch.load(path))
     return model
 
 # 학습 함수
-def train(model, criterion, optimizer, train_loader, val_loader, epochs=10):
+def train(model, criterion, optimizer, train_loader, val_loader, epochs=10, path='best_ResNet_model.pth'):
     best_acc = 0.0
     os.makedirs("ResNet_models", exist_ok=True)  # 폴더가 없으면 생성
+    path = os.path.join(BASE_DIR, "models/ResNet_models", path)
     
     for epoch in range(epochs):
         model.train()
@@ -56,7 +59,7 @@ def train(model, criterion, optimizer, train_loader, val_loader, epochs=10):
         
         if val_acc > best_acc:
             best_acc = val_acc
-            torch.save(model.state_dict(), "ResNet_models/best_ResNet_model.pth")
+            torch.save(model.state_dict(), path)
             print("Best model saved!")
 
 # 검증 함수

--- a/models/ResNet.py
+++ b/models/ResNet.py
@@ -97,7 +97,7 @@ def run_ResNet(train_loader, val_loader, test_loader, lr=0.001, only_test=False)
         return test_acc
     
     train(model, criterion, optimizer, train_loader, val_loader)
-    test_ResNet(model, test_loader)
+    test_ResNet(test_loader)
 
 # 랜덤 샘플 시각화 함수
 def ResNet_visualize_predictions(data_loader, num_samples=5):

--- a/models/ResNet.py
+++ b/models/ResNet.py
@@ -77,7 +77,7 @@ def test_ResNet(model, test_loader):
 def run_ResNet(train_loader, val_loader, test_loader, lr=0.001, only_test=False):
     # 모델 초기화
     model = MNISTResNet().to(device)
-
+    
     # 손실 함수 및 옵티마이저 정의
     criterion = nn.CrossEntropyLoss()
     optimizer = optim.Adam(model.parameters(), lr=lr)

--- a/models/ResNet.py
+++ b/models/ResNet.py
@@ -84,7 +84,7 @@ def test_ResNet(test_loader, path='best_ResNet_model.pth'):
     return test_acc
 
 # 학습 실행 함수
-def run_ResNet(train_loader, val_loader, test_loader, lr=0.001, only_test=False, path='best_ResNet_model.pth'):
+def run_ResNet(train_loader=None, val_loader=None, test_loader=None, lr=0.001, epochs=10, only_test=False, path='best_ResNet_model.pth'):
     # 모델 초기화
     model = load_ResNet_model()
     
@@ -96,7 +96,7 @@ def run_ResNet(train_loader, val_loader, test_loader, lr=0.001, only_test=False,
         test_acc = test_ResNet(model, test_loader)
         return test_acc
     
-    train(model, criterion, optimizer, train_loader, val_loader)
+    train(model, criterion, optimizer, train_loader, val_loader, epochs, path)
     test_ResNet(test_loader, path=path)
 
 # 랜덤 샘플 시각화 함수

--- a/models/ResNet.py
+++ b/models/ResNet.py
@@ -29,7 +29,7 @@ def load_ResNet_model(best=False, path='best_ResNet_model.pth'):
     return model
 
 # 학습 함수
-def train(model, criterion, optimizer, train_loader, val_loader, epochs=10, path='best_ResNet_model.pth'):
+def train_ResNet(model, criterion, optimizer, train_loader, val_loader, epochs=10, path='best_ResNet_model.pth'):
     best_acc = 0.0
     os.makedirs("ResNet_models", exist_ok=True)  # 폴더가 없으면 생성
     path = os.path.join(BASE_DIR, "models/ResNet_models", path)
@@ -77,14 +77,15 @@ def evaluate(model, loader):
     return correct / total
 
 # 테스트 함수
-def test_ResNet(test_loader, path='best_ResNet_model.pth'):
+def test_ResNet(test_loader, path='best_ResNet_model.pth', print=True):
     model = load_ResNet_model(best=True, path=path)
     test_acc = evaluate(model, test_loader)
-    print(f"Test Accuracy: {test_acc:.4f}")
+    if print:
+        print(f"Test Accuracy: {test_acc:.4f}")
     return test_acc
 
 # 학습 실행 함수
-def run_ResNet(train_loader=None, val_loader=None, test_loader=None, lr=0.001, epochs=10, only_test=False, path='best_ResNet_model.pth'):
+def run_ResNet(train_loader, val_loader, test_loader, lr=0.001, epochs=10, path='best_ResNet_model.pth'):
     # 모델 초기화
     model = load_ResNet_model()
     
@@ -92,11 +93,7 @@ def run_ResNet(train_loader=None, val_loader=None, test_loader=None, lr=0.001, e
     criterion = nn.CrossEntropyLoss()
     optimizer = optim.Adam(model.parameters(), lr=lr)
     
-    if only_test:
-        test_acc = test_ResNet(model, test_loader)
-        return test_acc
-    
-    train(model, criterion, optimizer, train_loader, val_loader, epochs, path)
+    train_ResNet(model, criterion, optimizer, train_loader, val_loader, epochs, path)
     test_ResNet(test_loader, path=path)
 
 # 랜덤 샘플 시각화 함수


### PR DESCRIPTION
## 🛠 **기능**
### **1. ResNet-18 모델 정의 (`MNISTResNet`)**
- 사전 학습된 `resnet18`을 사용하여 MNIST 분류 모델 생성
- 첫 번째 합성곱(`conv1`)을 **1채널 입력(MNIST 흑백 이미지) 지원**하도록 수정
- `fc` 레이어를 **10개 클래스(MNIST 숫자 0~9)**를 예측하도록 변경

### **2. 모델 로드 (`load_ResNet_model`)**
- 새 모델을 생성하여 반환
- 미리 학습된 모델 파일을 불러오는 기능 제공

### **3. 모델 학습 (`train_ResNet`)**
- 손실 함수: `CrossEntropyLoss`
- 옵티마이저: `Adam`
- `train_loader`와 `val_loader`를 사용해 모델 학습 및 검증 수행
- **가장 높은 검증 정확도를 기록한 모델을 저장**

### **4. 모델 평가 (`evaluate`)**
- 주어진 데이터 로더(`train_loader`, `val_loader`, `test_loader`)를 기반으로 모델 성능 평가
- `test_ResNet()`을 사용하여 학습된 모델을 불러와 테스트 정확도 출력

### **5. 모델 실행 (`run_ResNet`)**
- `only_test=True`이면, 학습 없이 테스트 데이터셋만 평가
- `only_test=False`이면, **모델 학습 후 테스트 데이터 평가 수행**

### **6. 랜덤 샘플 예측 결과 시각화 (`ResNet_visualize_predictions`)**
- `data_loader`에서 **랜덤으로 5개의 샘플을 선택**
- 모델이 예측한 값과 실제 라벨을 비교하여 **시각적으로 출력**

---

## 🏗 **사용 방법**
### **1. 모델 학습**
```python
run_ResNet(train_loader, val_loader, test_loader, lr=0.001, path='원하는 모델 저장 파일 이름 (.pth)')
```
- `train_loader`, `val_loader`, `test_loader`를 입력하면 **학습 및 평가 수행**
- `lr`: 학습률 설정 가능 (기본값 `0.001`)

### **2. 테스트 데이터만 평가**
```python
test_ResNet(test_loader, path='저장 해놓은 모델 저장 파일 이름 (.pth)', print=False)
```
- 사전 학습된 모델을 로드하여 테스트 성능 평가
- test acc 값 반환을 통해 다른 모델과 비교 가능
- print 인자로 acc값을 함수내에서 print 할지 말지 결정 (기본값은 True)

### **3. 랜덤 샘플 예측 결과 시각화**
```python
ResNet_visualize_predictions(test_loader, num_samples=5, path='저장 해놓은 모델 저장 파일 이름 (.pth)')
```
- 테스트 데이터에서 **랜덤으로 5개 샘플을 뽑아 예측 결과를 시각화**